### PR TITLE
fix: gisus comment load method & page-ref style

### DIFF
--- a/logseq/custom.css
+++ b/logseq/custom.css
@@ -73,11 +73,10 @@ hr {
   --aoni: #516E41;
   --ls-tag-text-opacity: .7;
   --ls-highlight-color: var(--usuao);
-  --ls-link-text-color: var(--aoni);
   --ls-highlight-text-color: var(--aoni);
+  --ls-link-text-color: var(--aoni);
 }
 .light-theme, html[data-theme="light"]{
-  --ls-selection-background-color: var(--ls-highlight-color);
   --ls-tag-background-hover: var(--color-level-1);
   --ls-page-blockquote-border-color: var(--ls-highlight-color);
   --ls-page-blockquote-bg-color: var(--color-level-3);
@@ -87,7 +86,6 @@ hr {
 
 @media (prefers-color-scheme: dark) {
   .light-theme, html[data-theme="light"]{
-    --ls-selection-background-color: var(--ls-highlight-color);
     --ls-tag-background-hover: var(--color-level-1);
     --ls-page-blockquote-border-color: var(--ls-highlight-color);
     --ls-page-blockquote-bg-color: var(--color-level-3);
@@ -103,6 +101,9 @@ mark>code {
 }
 mark>a {
   color: black !important;
+}
+.page-ref {
+  color: var(--ls-highlight-text-color);
 }
 
 

--- a/logseq/custom.css
+++ b/logseq/custom.css
@@ -60,7 +60,6 @@
  * style[required]: custom horizontal rule.
  */
 hr {
-  /* border-color: var(--); */
   margin: 1rem 0;
 }
 
@@ -74,22 +73,17 @@ hr {
   --ls-tag-text-opacity: .7;
   --ls-highlight-color: var(--usuao);
   --ls-link-text-color: var(--aoni);
-  --ls-highlight-text-color: var(--aoni);
-}
-.light-theme, html[data-theme="light"]{
+
+  --ls-tag-background-hover: var(--color-level-1)
+  --ls-highlight-text-color: var(--ls-link-text-color);
+  --ls-selection-background-color: var(--ls-highlight-color);
   --ls-page-blockquote-border-color: var(--ls-highlight-color);
   --ls-page-blockquote-bg-color: var(--color-level-3);
   --ls-page-mark-bg-color: var(--ls-highlight-color);
-  --ls-page-properties-background-color: var(--color-level-3);
+  --ls-page-properties-background-color: var(--color-level-3);  
 }
 
 @media (prefers-color-scheme: dark) {
-  .light-theme, html[data-theme="light"]{
-    --ls-page-blockquote-border-color: var(--ls-highlight-color);
-    --ls-page-blockquote-bg-color: var(--color-level-3);
-    --ls-page-mark-bg-color: var(--ls-highlight-color);
-    --ls-page-properties-background-color: var(--color-level-3);
-  }
   img {
     filter: brightness(.80) contrast(1.1);
   }
@@ -107,6 +101,7 @@ mark>a {
  */
 a.tag {
   display: inline;
+  background: none;
   border: 1.5px dashed var(--ls-highlight-text-color, #045591);
   color: var(--ls-highlight-text-color);
 }

--- a/logseq/custom.css
+++ b/logseq/custom.css
@@ -60,6 +60,7 @@
  * style[required]: custom horizontal rule.
  */
 hr {
+  /* border-color: var(--); */
   margin: 1rem 0;
 }
 
@@ -73,17 +74,26 @@ hr {
   --ls-tag-text-opacity: .7;
   --ls-highlight-color: var(--usuao);
   --ls-link-text-color: var(--aoni);
-
-  --ls-tag-background-hover: var(--color-level-1)
-  --ls-highlight-text-color: var(--ls-link-text-color);
+  --ls-highlight-text-color: var(--aoni);
+}
+.light-theme, html[data-theme="light"]{
   --ls-selection-background-color: var(--ls-highlight-color);
+  --ls-tag-background-hover: var(--color-level-1);
   --ls-page-blockquote-border-color: var(--ls-highlight-color);
   --ls-page-blockquote-bg-color: var(--color-level-3);
   --ls-page-mark-bg-color: var(--ls-highlight-color);
-  --ls-page-properties-background-color: var(--color-level-3);  
+  --ls-page-properties-background-color: var(--color-level-3);
 }
 
 @media (prefers-color-scheme: dark) {
+  .light-theme, html[data-theme="light"]{
+    --ls-selection-background-color: var(--ls-highlight-color);
+    --ls-tag-background-hover: var(--color-level-1);
+    --ls-page-blockquote-border-color: var(--ls-highlight-color);
+    --ls-page-blockquote-bg-color: var(--color-level-3);
+    --ls-page-mark-bg-color: var(--ls-highlight-color);
+    --ls-page-properties-background-color: var(--color-level-3);
+  }
   img {
     filter: brightness(.80) contrast(1.1);
   }

--- a/logseq/inject.html
+++ b/logseq/inject.html
@@ -13,7 +13,7 @@
         data-repo-id="R_kgDOKbDA0w"
         data-category="Giscus"
         data-category-id="DIC_kwDOKbDA084Cfouf"
-        data-mapping="pathname"
+        data-mapping="title"
         data-strict="0"
         data-reactions-enabled="1"
         data-emit-metadata="0"


### PR DESCRIPTION
firstly, the usage of pathname is not suitable while using submain domain and github pages meanwhile, for instances, with the page `content`, we will see two different topic like, `index` and `soul/(index)`. then, the style show of ref-page is not working like local written. so debug on github action and pull this request.